### PR TITLE
fix: enum check breaks on some classes

### DIFF
--- a/src/main/java/com/Hileb/teampotato.redirectionor/RedirectionorFastUtil.java
+++ b/src/main/java/com/Hileb/teampotato.redirectionor/RedirectionorFastUtil.java
@@ -20,11 +20,13 @@ public class RedirectionorFastUtil {
                 case 4:
                 case 12:
                 case 18:
+                case 17:
                     size = 5;
                     break;
                 case 5:
                 case 6:
                     size = 9;
+                    ++i;
                     break;
                 case 1:
                     size = 3 + readUnsignedShort(clazz,passcount + 1);


### PR DESCRIPTION
Some classes like BoundedLocalCache (see #10) from caffeine make the code return true when it shouldn't. This was caused by long and double constant being handled incorrectly. Also fixed dynamic constants not having the right size.

Tested it with Intellij debugger and made sure the result of the method is now right.

Tested it on Forge 1.8.9 with multiple mods having Essential as a dependency (which bundles that BoundedLocalCache class), now works fine.

This should make the mod way more stable and compatible with a lot of other mods.

You'll have to port this to other branches too though.